### PR TITLE
0.23.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ npm-debug.log.*
 thumbs.db
 !.gitkeep
 src/main/lib/process/debug/*.json
+src/lib/reporters/phpunit/bootstrap
 tests/coverage
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "Lode",
-  "version": "0.22.3",
+  "version": "0.23.0",
   "author": "Tomas Buteler <info@lode.run>",
   "description": "A universal GUI for unit testing",
   "license": "MIT",

--- a/src/lib/reporters/phpunit/bootstrap.php
+++ b/src/lib/reporters/phpunit/bootstrap.php
@@ -36,6 +36,12 @@ spl_autoload_register(function ($class) {
     }
 });
 
+if (!function_exists('console')) {
+    function console() {
+        call_user_func_array([\LodeApp\PHPUnit\Console::class, 'log'], func_get_args());
+    }
+}
+
 // Remember actual bootstrap location in case PHPUnit boots another process
 // for tests running in isolation.
 file_put_contents(__DIR__ . DIRECTORY_SEPARATOR . 'bootstrap', $bootstrap);

--- a/src/lib/reporters/phpunit/src/48-57/LodeReporter.php
+++ b/src/lib/reporters/phpunit/src/48-57/LodeReporter.php
@@ -150,7 +150,7 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addSuccess(PHPUnit_Framework_Test $test, $time)
     {
-        $this->progress($this->render($test, null, $time));
+        $this->progress($this->render($test, 'passed', null, $time));
     }
 
     /**
@@ -162,7 +162,7 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'failed', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -175,7 +175,7 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'failed', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -188,7 +188,7 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_Warning $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'warning', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -201,7 +201,7 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'incomplete', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -214,7 +214,7 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'empty', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -227,20 +227,25 @@ class LodeReporter extends PHPUnit_TextUI_ResultPrinter
      */
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'skipped', $e, $time));
         $this->lastTestFailed = true;
     }
 
     /**
      * Render a test report.
      *
+     * Don't rely on status from the test object, as it could be null
+     * (and even be cast as passed in PHPUnit 7+), which can be the case
+     * for tests running in separate processes.
+     *
      * @param \PHPUnit_Framework_Test $test
+     * @param string $status
      * @param \Exception|null $t
      * @param float $time
      */
-    protected function render($test, Exception $t = null, $time)
+    protected function render($test, $status, Exception $t = null, $time)
     {
-        $report = new Report($test);
+        $report = new Report($test, $status);
 
         if ($t) {
             $report->withException($t);

--- a/src/lib/reporters/phpunit/src/60-65/LodeReporter.php
+++ b/src/lib/reporters/phpunit/src/60-65/LodeReporter.php
@@ -150,7 +150,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addSuccess(Test $test, $time)
     {
-        $this->progress($this->render($test, null, $time));
+        $this->progress($this->render($test, 'passed', null, $time));
     }
 
     /**
@@ -162,7 +162,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addError(Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'failed', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -175,7 +175,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addFailure(Test $test, AssertionFailedError $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'failed', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -188,7 +188,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addWarning(Test $test, Warning $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'warning', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -201,7 +201,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addIncompleteTest(Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'incomplete', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -214,7 +214,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addRiskyTest(Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'empty', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -227,20 +227,25 @@ class LodeReporter extends ResultPrinter
      */
     public function addSkippedTest(Test $test, Exception $e, $time)
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'skipped', $e, $time));
         $this->lastTestFailed = true;
     }
 
     /**
      * Render a test report.
      *
+     * Don't rely on status from the test object, as it could be null
+     * (and even be cast as passed in PHPUnit 7+), which can be the case
+     * for tests running in separate processes.
+     *
      * @param \PHPUnit\Framework\Test $test
+     * @param string $status
      * @param \Exception|null $t
      * @param float $time
      */
-    protected function render($test, Exception $t = null, $time)
+    protected function render($test, $status, Exception $t = null, $time)
     {
-        $report = new Report($test);
+        $report = new Report($test, $status);
 
         if ($t) {
             $report->withException($t);

--- a/src/lib/reporters/phpunit/src/LodeReporter.php
+++ b/src/lib/reporters/phpunit/src/LodeReporter.php
@@ -150,7 +150,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addSuccess(Test $test, float $time): void
     {
-        $this->progress($this->render($test, null, $time));
+        $this->progress($this->render($test, 'passed', null, $time));
     }
 
     /**
@@ -162,7 +162,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addError(Test $test, Throwable $t, float $time): void
     {
-        $this->progress($this->render($test, $t, $time));
+        $this->progress($this->render($test, 'failed', $t, $time));
         $this->lastTestFailed = true;
     }
 
@@ -175,7 +175,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addFailure(Test $test, AssertionFailedError $e, float $time): void
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'failed', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -188,7 +188,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {
-        $this->progress($this->render($test, $e, $time));
+        $this->progress($this->render($test, 'warning', $e, $time));
         $this->lastTestFailed = true;
     }
 
@@ -201,7 +201,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addIncompleteTest(Test $test, Throwable $t, float $time): void
     {
-        $this->progress($this->render($test, $t, $time));
+        $this->progress($this->render($test, 'incomplete', $t, $time));
         $this->lastTestFailed = true;
     }
 
@@ -214,7 +214,7 @@ class LodeReporter extends ResultPrinter
      */
     public function addRiskyTest(Test $test, Throwable $t, float $time): void
     {
-        $this->progress($this->render($test, $t, $time));
+        $this->progress($this->render($test, 'empty', $t, $time));
         $this->lastTestFailed = true;
     }
 
@@ -227,20 +227,25 @@ class LodeReporter extends ResultPrinter
      */
     public function addSkippedTest(Test $test, Throwable $t, float $time): void
     {
-        $this->progress($this->render($test, $t, $time));
+        $this->progress($this->render($test, 'skipped', $t, $time));
         $this->lastTestFailed = true;
     }
 
     /**
      * Render a test report.
      *
+     * Don't rely on status from the test object, as it could be null
+     * (and even be cast as passed in PHPUnit 7+), which can be the case
+     * for tests running in separate processes.
+     *
      * @param \PHPUnit\Framework\Test $test
+     * @param string $status
      * @param \Throwable|null $t
      * @param float $time
      */
-    protected function render($test, Throwable $t = null, float $time): array
+    protected function render($test, $status, Throwable $t = null, float $time): array
     {
-        $report = new Report($test);
+        $report = new Report($test, $status);
 
         if ($t) {
             $report->withException($t);

--- a/src/lib/reporters/phpunit/src/Report.php
+++ b/src/lib/reporters/phpunit/src/Report.php
@@ -11,21 +11,6 @@ use Throwable;
 class Report
 {
     /**
-     * A map of PHPUnit vs. Lode string statuses
-     *
-     * @var array
-     */
-    protected $statuses = [
-        0 => 'passed', // PASSED
-        1 => 'skipped', // SKIPPED
-        2 => 'incomplete', // INCOMPLETE
-        3 => 'failed', // FAILURE
-        4 => 'failed', // ERROR
-        5 => 'empty', // RISKY
-        6 => 'warning', // WARNING
-    ];
-
-    /**
      * Name prettifier, for consistent transformations.
      *
      * @var \PHPUnit\Util\TestDox\NamePrettifier
@@ -46,6 +31,14 @@ class Report
      * @var PHPUnit\Framework\Test
      */
     protected $test;
+
+    /**
+     * The outcome of the test run, standardised
+     * for display inside of Lode.
+     *
+     * @var string
+     */
+    protected $status;
 
     /**
      * The exception triggered by the test, if any.
@@ -86,10 +79,12 @@ class Report
      * Create a new Lode report class.
      *
      * @param \PHPUnit\Framework\Test $test
+     * @param string $status
      */
-    public function __construct(Test $test)
+    public function __construct(Test $test, $status = 'idle')
     {
         $this->test = $test;
+        $this->status = $status;
         $this->class = get_class($this->test);
         if ($this->isWarning()) {
             $original = $this->getWarningClass();
@@ -260,7 +255,7 @@ class Report
     public function render()
     {
         $current = array_merge($this->hydrateTest(), [
-            'status' => $this->status(),
+            'status' => $this->status,
             'feedback' => $this->exception ? (new Feedback($this->exception))->render() : null,
             'console' => $this->console->pullTestLogs($this->getFileName(), $this->test->getName()),
             'stats' => [
@@ -298,17 +293,6 @@ class Report
     protected function transformName(string $name)
     {
         return preg_replace('/^it\s/', '', $this->prettifier->prettifyTestMethod($name));
-    }
-
-    /**
-     * Map a PHPUnit status string into a standardized
-     * Lode status string.
-     *
-     * @return string
-     */
-    protected function status()
-    {
-        return Util::get($this->statuses, $this->test->getStatus(), 'warning');
     }
 
     /**

--- a/src/lib/reporters/phpunit/src/Report.php
+++ b/src/lib/reporters/phpunit/src/Report.php
@@ -199,8 +199,9 @@ class Report
             'displayName' => $this->transformName($name),
             'status' => 'idle',
             'feedback' => [],
-            'stats' => [],
             'console' => [],
+            'params' => '',
+            'stats' => [],
         ]);
     }
 
@@ -258,6 +259,7 @@ class Report
             'status' => $this->status,
             'feedback' => $this->exception ? (new Feedback($this->exception))->render() : null,
             'console' => $this->console->pullTestLogs($this->getFileName(), $this->test->getName()),
+            'params' => $this->usesDataProvider() ? $this->transformParameters($this->getDataSetAsString()) : '',
             'stats' => [
                 'duration' => $this->time,
                 'assertions' => $this->getNumAssertions(),
@@ -293,6 +295,17 @@ class Report
     protected function transformName(string $name)
     {
         return preg_replace('/^it\s/', '', $this->prettifier->prettifyTestMethod($name));
+    }
+
+    /**
+     * Clean-up the data-as-string provided by PHPUnit.
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function transformParameters(string $data): string
+    {
+        return preg_replace('/^ with data set (#\d*|".*") \((.*)\)/', '$2', $data);
     }
 
     /**

--- a/src/renderer/components/Diff.vue
+++ b/src/renderer/components/Diff.vue
@@ -42,7 +42,7 @@ export default {
     },
     computed: {
         diff () {
-            return _get(this.parts, 'diff', '')
+            return this.formatDiff(_get(this.parts, 'diff', ''))
         },
         parts () {
             if (typeof this.content === 'string') {
@@ -52,20 +52,24 @@ export default {
             }
 
             return _pickBy({
-                'diff': _get(this.content, '@', ''),
+                'diff': this.formatDiff(_get(this.content, '@', '')),
                 'actual': _get(this.content, '+', ''),
                 'expected': _get(this.content, '-', ''),
                 'expected-partial': _get(this.content, 'q', '')
             }, _identity)
         },
         hasSupporting () {
-            return Object.keys(this.parts).length > 1
+            return typeof this.content !== 'string'
         },
         hasDiff () {
             return typeof this.parts.diff !== 'undefined'
         }
     },
     methods: {
+        formatDiff (diff) {
+            // Clean chunk headers without any line information.
+            return diff.replace(/\n@@ @@\n/, '\n\n')
+        },
         partName (key) {
             return _get({
                 'diff': 'Difference',

--- a/src/renderer/components/Feedback.vue
+++ b/src/renderer/components/Feedback.vue
@@ -2,7 +2,7 @@
     <div class="feedback">
         <h4>{{ content.title }}</h4>
         <p class="message">
-            <span v-if="content.text" v-markdown="content.text"></span>
+            <span v-if="content.text">{{ content.text }}</span>
             <template v-if="content.ansi">
                 <Ansi :content="content.ansi" />
             </template>

--- a/src/renderer/components/Parameters.vue
+++ b/src/renderer/components/Parameters.vue
@@ -1,0 +1,17 @@
+<template>
+    <div class="parameters">
+        <pre><code>{{ parameters }}</code></pre>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'Parameters',
+    props: {
+        parameters: {
+            type: String,
+            required: true
+        }
+    }
+}
+</script>

--- a/src/renderer/components/TestResult.vue
+++ b/src/renderer/components/TestResult.vue
@@ -12,6 +12,9 @@
                         <button type="button" v-if="feedback" @mousedown="setTab('feedback')" class="tab" :class="{ selected: tab === 'feedback' }">
                             Feedback
                         </button>
+                        <button type="button" v-if="parameters" @mousedown="setTab('parameters')" class="tab" :class="{ selected: tab === 'parameters' }">
+                            Parameters
+                        </button>
                         <button type="button" v-if="console" @mousedown="setTab('console')" class="tab" :class="{ selected: tab === 'console' }">
                             Console
                         </button>
@@ -40,6 +43,9 @@
                     <!-- Catch-all for unknown content -->
                     <pre v-else><code>{{ feedback.content }}</code></pre>
                 </div>
+                <div v-else-if="parameters && tab === 'parameters'">
+                    <Parameters :parameters="parameters" />
+                </div>
                 <div v-else-if="console && tab === 'console'">
                     <Console v-for="(output, index) in console" :key="`console-${index}`" :output="output" />
                 </div>
@@ -65,6 +71,7 @@ import Ansi from '@/components/Ansi'
 import Console from '@/components/Console'
 import Feedback from '@/components/Feedback'
 import KeyValue from '@/components/KeyValue'
+import Parameters from '@/components/Parameters'
 import TestInformation from '@/components/TestInformation'
 
 export default {
@@ -74,6 +81,7 @@ export default {
         Console,
         Feedback,
         KeyValue,
+        Parameters,
         TestInformation
     },
     props: {
@@ -103,6 +111,8 @@ export default {
                 return 'suiteConsole'
             } else if (this.stats) {
                 return 'stats'
+            } else if (this.parameters) {
+                return 'parameters'
             }
         },
         test () {
@@ -125,6 +135,9 @@ export default {
         },
         feedback () {
             return this.result && this.result.feedback && this.result.feedback.content ? this.result.feedback : false
+        },
+        parameters () {
+            return this.result && this.result.params
         },
         console () {
             return this.result && this.result.console && this.result.console.length ? this.result.console : false

--- a/src/styles/blocks/feedback.scss
+++ b/src/styles/blocks/feedback.scss
@@ -12,6 +12,10 @@
         margin-top: var(--spacing-half);
         margin-bottom: var(--spacing-and-half);
 
+        :not(:empty) {
+            white-space: pre-wrap;
+        }
+
         code {
             background-color: $blue-100;
             border-radius: 2px;

--- a/support/release-notes.md
+++ b/support/release-notes.md
@@ -1,5 +1,9 @@
+New:
+    - Data parameters from PHPUnit are now shown in the "Parameters" tab in the results pane
+    - `console` helper in PHPUnit to help debug tests while running Lode
 Changed:
     - Improved parsing of Jest failure feedback
+    - Improved rendering of feedback text
     - Always use panels for diff
 Fixed:
     - PHPUnit unable to run tests in separate processes

--- a/support/release-notes.md
+++ b/support/release-notes.md
@@ -1,2 +1,5 @@
+Changed:
+    - Improved parsing of Jest failure feedback
+    - Always use panels for diff
 Fixed:
-    - Security fixes - #10 #11
+    - PHPUnit unable to run tests in separate processes


### PR DESCRIPTION
New:
    - Data parameters from PHPUnit are now shown in the "Parameters" tab in the results pane
    - `console` helper in PHPUnit to help debug tests while running Lode
Changed:
    - Improved parsing of Jest failure feedback
    - Improved rendering of feedback text
    - Always use panels for diff
Fixed:
    - PHPUnit unable to run tests in separate processes
