### PR TITLE
Pre-compile main process using dotprejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "css-loader": "^3.2.0",
     "del": "^3.0.0",
     "devtron": "^1.4.0",
+    "dotprejs": "^0.0.2",
     "electron": "^6.0.2",
     "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",

--- a/workflow/webpack.main.config.js
+++ b/workflow/webpack.main.config.js
@@ -9,6 +9,7 @@ const { dependencies } = require('../package.json')
 const webpack = require('webpack')
 
 const MinifyPlugin = require('babel-minify-webpack-plugin')
+const PreJSPlugin = require('dotprejs/src/PreJSPlugin')
 
 const mainConfig = {
     entry: {
@@ -97,6 +98,10 @@ if (process.env.NODE_ENV === 'production') {
         new MinifyPlugin(),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': '"production"'
+        }),
+        new PreJSPlugin({
+            assets: ['main.js'],
+            runtime: require('electron')
         })
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3667,6 +3667,13 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
   integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
 
+dotprejs@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/dotprejs/-/dotprejs-0.0.2.tgz#76b4a550a8ff04435e0faef9a5b631b22077bb8b"
+  integrity sha512-eMfL+L1WZMJn1l7+uDk9/dtFHafx9g8HONQ8GzfSN3Ai21aTrTWZg25iCBUJ0x3+C7jDCefHTOjwNEenif4dTA==
+  dependencies:
+    fs-extra "^8.1.0"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
Pre-compiling the main process' script using [dotprejs](https://github.com/MarshallOfSound/dotprejs) makes the loading of the app roughly 40% faster by my measurements. MacOS seems to have some optimisations of its own, so subsequent loads are mostly unaffected, but this brings us a bit closer to native-like loading times.

Pre-compilation does not work for the renderer script.