### PR TITLE
Better tab navigation in test result pane

### DIFF
--- a/src/renderer/components/Nugget.vue
+++ b/src/renderer/components/Nugget.vue
@@ -8,8 +8,7 @@
             hasChildren ? 'has-children' : ''
         ]"
         tabindex="0"
-        @keydown.stop.right="handleExpand"
-        @keydown.stop.left="handleCollapse"
+        @keydown="handleKeydown"
     >
         <div class="seam"></div>
         <div class="header" @click.prevent @mousedown.prevent.stop="handleActivate">
@@ -91,6 +90,15 @@ export default {
                 return
             }
             this.toggleChildren(event)
+        },
+        handleKeydown (event) {
+            if (event.code === 'ArrowRight' && !this.$input.isCycleForward(event)) {
+                event.stopPropagation()
+                this.handleExpand(event)
+            } else if (event.code === 'ArrowLeft' && !this.$input.isCycleBackward(event)) {
+                event.stopPropagation()
+                this.handleCollapse(event)
+            }
         },
         handleExpand (event) {
             if (!this.hasChildren || this.show) {

--- a/src/renderer/components/TestResult.vue
+++ b/src/renderer/components/TestResult.vue
@@ -74,6 +74,7 @@
 </template>
 
 <script>
+import { mapGetters, mapActions } from 'vuex'
 import _get from 'lodash/get'
 import _identity from 'lodash/identity'
 import _indexOf from 'lodash/indexOf'
@@ -113,6 +114,13 @@ export default {
         tab () {
             if (this.active) {
                 return this.active
+            } else if (this.lastActiveTab) {
+                // If store has a previously active tab from other results,
+                // and that same tab exists in this new pane, set that in order
+                // to allow some consistency when navigating between test results.
+                if (_indexOf(this.availableTabs, this.lastActiveTab) > -1) {
+                    return this.lastActiveTab
+                }
             }
 
             // If no tab is active, return the first available one.
@@ -171,7 +179,10 @@ export default {
             }
 
             return this.suite && this.suite.getConsole() && this.suite.getConsole().length ? this.suite.getConsole() : false
-        }
+        },
+        ...mapGetters({
+            lastActiveTab: 'tabs/lastActive'
+        })
     },
     mounted () {
         let index
@@ -206,13 +217,17 @@ export default {
     methods: {
         setTab (tab) {
             this.active = tab
+            this.setLastActiveTab(this.active)
         },
         refreshFramework () {
             if (!this.framework) {
                 return
             }
             this.framework.refresh()
-        }
+        },
+        ...mapActions({
+            setLastActiveTab: 'tabs/setLastActive'
+        })
     }
 }
 </script>

--- a/src/renderer/components/TestResult.vue
+++ b/src/renderer/components/TestResult.vue
@@ -177,7 +177,13 @@ export default {
         let index
         this.cycleHandler = (e) => {
             if (this.availableTabs.length > 1) {
-                if (this.$input.isCycleForward(e)) {
+                if (this.$input.isNumeral(e) && this.$input.hasCmdOrCtrl(e)) {
+                    index = event.key - 1 // Tab order starts at 1, not zero.
+                    const seek = this.availableTabs[index]
+                    if (seek) {
+                        this.setTab(seek)
+                    }
+                } else if (this.$input.isCycleForward(e)) {
                     index = _indexOf(this.availableTabs, this.tab) + 1
                     const forward = this.availableTabs[index >= this.availableTabs.length ? 0 : index]
                     if (forward) {

--- a/src/renderer/plugins/input.js
+++ b/src/renderer/plugins/input.js
@@ -63,6 +63,22 @@ export default class Input {
     isRightButton (event) {
         return event.which === 3 || event.button === 2
     }
+    isCycleForward (event) {
+        if (__WIN32__) {
+            return (event.code === 'Tab' && event.ctrlKey) || (event.code === 'PageUp' && event.ctrlKey)
+        } else if (event.metaKey) {
+            return (event.code === 'BracketRight' && event.shiftKey) || (event.code === 'ArrowRight' && event.altKey)
+        }
+        return false
+    }
+    isCycleBackward (event) {
+        if (__WIN32__) {
+            return (event.code === 'Tab' && event.shiftKey && event.ctrlKey) || (event.code === 'PageDown' && event.ctrlKey)
+        } else if (event.metaKey) {
+            return (event.code === 'BracketLeft' && event.shiftKey) || (event.code === 'ArrowLeft' && event.altKey)
+        }
+        return false
+    }
     modifiesContent (event) {
         return !this.isAuxiliaryAction(event) && !this.isAuxiliaryKey(event)
     }

--- a/src/renderer/plugins/input.js
+++ b/src/renderer/plugins/input.js
@@ -45,6 +45,9 @@ export default class Input {
     hasModifierKey (event) {
         return event.ctrlKey || event.metaKey || event.altKey || event.shiftKey
     }
+    hasCmdOrCtrl (event) {
+        return (__WIN32__ && event.ctrlKey) || (!__WIN32__ && event.metaKey)
+    }
     hasAltKey (event) {
         return event.altKey
     }
@@ -62,6 +65,9 @@ export default class Input {
     }
     isRightButton (event) {
         return event.which === 3 || event.button === 2
+    }
+    isNumeral (event) {
+        return event.code.startsWith('Digit')
     }
     isCycleForward (event) {
         if (__WIN32__) {

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -1,0 +1,27 @@
+export default {
+    namespaced: true,
+    state: {
+        lastActive: ''
+    },
+    mutations: {
+        SET_LAST_ACTIVE (state, payload) {
+            state.lastActive = payload
+        },
+        CLEAR (state) {
+            state.lastActive = ''
+        }
+    },
+    actions: {
+        setLastActive: ({ commit }, tab) => {
+            commit('SET_LAST_ACTIVE', tab)
+        },
+        clear: ({ commit }) => {
+            commit('CLEAR')
+        }
+    },
+    getters: {
+        lastActive: (state) => {
+            return state.lastActive
+        }
+    }
+}


### PR DESCRIPTION
Introduces Chrome-like tab navigation for the tabs in the test result pane, when applicable.

**Windows**
- `Ctrl+Tab` or `Ctrl+Page Up` to cycle forwards
- `Ctrl+Shift+Tab` or `Ctrl+Page Down` to cycle backwards.
- `Ctrl+{#}` to jump to tab (where {1} is the first from left to right

**macOS**
- `Cmd+Shift+Right Bracket` or `Cmd+Option+Right` to cycle forwards
- `Cmd+Shift+Left Bracket` or `Cmd+Option+Left` to cycle backwards.
- `Cmd+{#}` to jump to tab (where {1} is the first from left to right

Also, if a tab is selected by the user, it will persist throughout tests (if it exists in the new test being focused).